### PR TITLE
Fix EF Core references and namespaces

### DIFF
--- a/src/DBStore.Domain/Contracts/IAuditLogRepository.cs
+++ b/src/DBStore.Domain/Contracts/IAuditLogRepository.cs
@@ -1,3 +1,5 @@
+namespace DBStore.Domain.Contracts;
+
 ﻿using DBStore.Domain.Entities;
 
 public interface IAuditLogRepository

--- a/src/DBStore.Domain/Contracts/ICartItemRepository.cs
+++ b/src/DBStore.Domain/Contracts/ICartItemRepository.cs
@@ -1,3 +1,5 @@
+namespace DBStore.Domain.Contracts;
+
 ﻿using DBStore.Domain.Entities;
 
 public interface ICartItemRepository

--- a/src/DBStore.Domain/Contracts/ICartRepository.cs
+++ b/src/DBStore.Domain/Contracts/ICartRepository.cs
@@ -1,3 +1,5 @@
+namespace DBStore.Domain.Contracts;
+
 ﻿using DBStore.Domain.Entities;
 
 public interface ICartRepository

--- a/src/DBStore.Domain/Contracts/IFavoriteRepository.cs
+++ b/src/DBStore.Domain/Contracts/IFavoriteRepository.cs
@@ -1,3 +1,5 @@
+namespace DBStore.Domain.Contracts;
+
 ﻿using DBStore.Domain.Entities;
 
 public interface IFavoriteRepository

--- a/src/DBStore.Domain/Contracts/IOrderItemRepository.cs
+++ b/src/DBStore.Domain/Contracts/IOrderItemRepository.cs
@@ -1,3 +1,5 @@
+namespace DBStore.Domain.Contracts;
+
 ﻿using DBStore.Domain.Entities;
 
 public interface IOrderItemRepository

--- a/src/DBStore.Domain/Contracts/IOrderRepository.cs
+++ b/src/DBStore.Domain/Contracts/IOrderRepository.cs
@@ -1,3 +1,5 @@
+namespace DBStore.Domain.Contracts;
+
 ﻿using DBStore.Domain.Entities;
 
 public interface IOrderRepository

--- a/src/DBStore.Domain/Contracts/IProductRepository.cs
+++ b/src/DBStore.Domain/Contracts/IProductRepository.cs
@@ -1,3 +1,5 @@
+namespace DBStore.Domain.Contracts;
+
 ﻿using DBStore.Domain.Entities;
 
 public interface IProductRepository

--- a/src/DBStore.Domain/Contracts/IRoleRepository.cs
+++ b/src/DBStore.Domain/Contracts/IRoleRepository.cs
@@ -1,3 +1,5 @@
+namespace DBStore.Domain.Contracts;
+
 ﻿using DBStore.Domain.Entities;
 
 public interface IRoleRepository

--- a/src/DBStore.Domain/Contracts/IShippingAddressRepository.cs
+++ b/src/DBStore.Domain/Contracts/IShippingAddressRepository.cs
@@ -1,3 +1,5 @@
+namespace DBStore.Domain.Contracts;
+
 ﻿using DBStore.Domain.Entities;
 
 public interface IShippingAddressRepository

--- a/src/DBStore.Domain/Contracts/IUserRepository.cs
+++ b/src/DBStore.Domain/Contracts/IUserRepository.cs
@@ -1,3 +1,5 @@
+namespace DBStore.Domain.Contracts;
+
 ﻿using DBStore.Domain.Entities;
 
 public interface IUserRepository

--- a/src/DBStore.Infrastructure/DBStore.Infrastructure.csproj
+++ b/src/DBStore.Infrastructure/DBStore.Infrastructure.csproj
@@ -11,6 +11,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.6" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- add EF Core runtime and Npgsql provider packages
- declare namespace `DBStore.Domain.Contracts` on each contract interface

## Testing
- `dotnet build DBStore.sln` *(fails: 'ApplicationDbContext' missing DbSets)*

------
https://chatgpt.com/codex/tasks/task_e_68518cec532483249a64810ac40d33aa