### PR TITLE
Add controllers and JWT config

### DIFF
--- a/src/DBStore.Api/Controllers/AuditLogsController.cs
+++ b/src/DBStore.Api/Controllers/AuditLogsController.cs
@@ -1,0 +1,30 @@
+using AutoMapper;
+using DBStore.Application.DTOs.Audit;
+using DBStore.Application.Interfaces;
+using DBStore.Domain.Entities;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DBStore.Api.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class AuditLogsController : ControllerBase
+    {
+        private readonly IAuditLogService _service;
+        private readonly IMapper _mapper;
+
+        public AuditLogsController(IAuditLogService service, IMapper mapper)
+        {
+            _service = service;
+            _mapper = mapper;
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<AuditLogDto>>> GetAll()
+        {
+            var logs = await _service.ListAllAsync();
+            var result = _mapper.Map<IEnumerable<AuditLogDto>>(logs);
+            return Ok(result);
+        }
+    }
+}

--- a/src/DBStore.Api/Controllers/CartsController.cs
+++ b/src/DBStore.Api/Controllers/CartsController.cs
@@ -1,0 +1,51 @@
+using AutoMapper;
+using DBStore.Application.DTOs.Cart;
+using DBStore.Application.Interfaces;
+using DBStore.Domain.Entities;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DBStore.Api.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class CartsController : ControllerBase
+    {
+        private readonly ICartService _service;
+        private readonly IMapper _mapper;
+
+        public CartsController(ICartService service, IMapper mapper)
+        {
+            _service = service;
+            _mapper = mapper;
+        }
+
+        [HttpGet("user/{userId}")]
+        public async Task<ActionResult<CartDto>> GetForUser(Guid userId)
+        {
+            var cart = await _service.GetOrCreateActiveCartAsync(userId);
+            var result = _mapper.Map<CartDto>(cart);
+            return Ok(result);
+        }
+
+        [HttpPost("{cartId}/items")]
+        public async Task<IActionResult> AddItem(Guid cartId, CartItemCreateDto dto)
+        {
+            await _service.AddItemAsync(cartId, dto.ProductId, dto.Quantity);
+            return NoContent();
+        }
+
+        [HttpDelete("items/{itemId}")]
+        public async Task<IActionResult> RemoveItem(Guid itemId)
+        {
+            await _service.RemoveItemAsync(itemId);
+            return NoContent();
+        }
+
+        [HttpPost("{cartId}/checkout")]
+        public async Task<IActionResult> Checkout(Guid cartId)
+        {
+            await _service.CheckoutAsync(cartId);
+            return NoContent();
+        }
+    }
+}

--- a/src/DBStore.Api/Controllers/FavoritesController.cs
+++ b/src/DBStore.Api/Controllers/FavoritesController.cs
@@ -1,0 +1,37 @@
+using AutoMapper;
+using DBStore.Application.DTOs.Favorites;
+using DBStore.Application.Interfaces;
+using DBStore.Domain.Entities;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DBStore.Api.Controllers
+{
+    [ApiController]
+    [Route("api/users/{userId}/[controller]")]
+    public class FavoritesController : ControllerBase
+    {
+        private readonly IFavoriteService _service;
+        private readonly IMapper _mapper;
+
+        public FavoritesController(IFavoriteService service, IMapper mapper)
+        {
+            _service = service;
+            _mapper = mapper;
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<FavoriteDto>>> Get(Guid userId)
+        {
+            var favs = await _service.ListByUserAsync(userId);
+            var result = _mapper.Map<IEnumerable<FavoriteDto>>(favs);
+            return Ok(result);
+        }
+
+        [HttpPost("{productId}")]
+        public async Task<IActionResult> Toggle(Guid userId, Guid productId)
+        {
+            await _service.ToggleFavoriteAsync(userId, productId);
+            return NoContent();
+        }
+    }
+}

--- a/src/DBStore.Api/Controllers/OrdersController.cs
+++ b/src/DBStore.Api/Controllers/OrdersController.cs
@@ -1,0 +1,54 @@
+using AutoMapper;
+using DBStore.Application.DTOs.Orders;
+using DBStore.Application.Interfaces;
+using DBStore.Domain.Entities;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DBStore.Api.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class OrdersController : ControllerBase
+    {
+        private readonly IOrderService _service;
+        private readonly IMapper _mapper;
+
+        public OrdersController(IOrderService service, IMapper mapper)
+        {
+            _service = service;
+            _mapper = mapper;
+        }
+
+        [HttpPost("user/{userId}")]
+        public async Task<ActionResult<OrderDto>> Create(Guid userId, OrderCreateDto dto)
+        {
+            var order = await _service.CreateOrderAsync(userId, dto.BillingAddressId);
+            var result = _mapper.Map<OrderDto>(order);
+            return CreatedAtAction(nameof(GetById), new { id = result.Id, userId }, result);
+        }
+
+        [HttpGet("{id}/user/{userId}")]
+        public async Task<ActionResult<OrderDto>> GetById(Guid id, Guid userId)
+        {
+            var order = await _service.GetByIdAsync(id, userId);
+            if (order == null) return NotFound();
+            return Ok(_mapper.Map<OrderDto>(order));
+        }
+
+        [HttpGet("user/{userId}")]
+        public async Task<ActionResult<IEnumerable<OrderDto>>> GetForUser(Guid userId)
+        {
+            var orders = await _service.ListByUserAsync(userId);
+            var result = _mapper.Map<IEnumerable<OrderDto>>(orders);
+            return Ok(result);
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<OrderDto>>> GetAll()
+        {
+            var orders = await _service.ListAllAsync();
+            var result = _mapper.Map<IEnumerable<OrderDto>>(orders);
+            return Ok(result);
+        }
+    }
+}

--- a/src/DBStore.Api/Controllers/ProductsController.cs
+++ b/src/DBStore.Api/Controllers/ProductsController.cs
@@ -1,0 +1,63 @@
+using AutoMapper;
+using DBStore.Application.DTOs.Products;
+using DBStore.Application.Interfaces;
+using DBStore.Domain.Entities;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DBStore.Api.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class ProductsController : ControllerBase
+    {
+        private readonly IProductService _service;
+        private readonly IMapper _mapper;
+
+        public ProductsController(IProductService service, IMapper mapper)
+        {
+            _service = service;
+            _mapper = mapper;
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<ProductDto>>> GetAll()
+        {
+            var products = await _service.ListAllAsync();
+            var result = _mapper.Map<IEnumerable<ProductDto>>(products);
+            return Ok(result);
+        }
+
+        [HttpGet("{id}")]
+        public async Task<ActionResult<ProductDto>> GetById(Guid id)
+        {
+            var product = await _service.GetByIdAsync(id);
+            if (product == null) return NotFound();
+            return Ok(_mapper.Map<ProductDto>(product));
+        }
+
+        [HttpPost]
+        public async Task<ActionResult<ProductDto>> Create(ProductCreateUpdateDto dto)
+        {
+            var product = _mapper.Map<Product>(dto);
+            product = await _service.CreateAsync(product);
+            var result = _mapper.Map<ProductDto>(product);
+            return CreatedAtAction(nameof(GetById), new { id = result.Id }, result);
+        }
+
+        [HttpPut("{id}")]
+        public async Task<IActionResult> Update(Guid id, ProductCreateUpdateDto dto)
+        {
+            var product = _mapper.Map<Product>(dto);
+            product.Id = id;
+            await _service.UpdateAsync(product);
+            return NoContent();
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete(Guid id)
+        {
+            await _service.DeleteAsync(id);
+            return NoContent();
+        }
+    }
+}

--- a/src/DBStore.Api/Controllers/ShippingAddressesController.cs
+++ b/src/DBStore.Api/Controllers/ShippingAddressesController.cs
@@ -1,0 +1,70 @@
+using AutoMapper;
+using DBStore.Application.DTOs.Shipping;
+using DBStore.Application.Interfaces;
+using DBStore.Domain.Entities;
+using Microsoft.AspNetCore.Mvc;
+using System.Linq;
+
+namespace DBStore.Api.Controllers
+{
+    [ApiController]
+    [Route("api/users/{userId}/[controller]")]
+    public class ShippingAddressesController : ControllerBase
+    {
+        private readonly IShippingAddressService _service;
+        private readonly IMapper _mapper;
+
+        public ShippingAddressesController(IShippingAddressService service, IMapper mapper)
+        {
+            _service = service;
+            _mapper = mapper;
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<ShippingAddressDto>>> List(Guid userId)
+        {
+            var addresses = await _service.ListByUserAsync(userId);
+            var result = _mapper.Map<IEnumerable<ShippingAddressDto>>(addresses);
+            return Ok(result);
+        }
+
+        [HttpPost]
+        public async Task<ActionResult<ShippingAddressDto>> Create(Guid userId, ShippingAddressCreateUpdateDto dto)
+        {
+            var entity = _mapper.Map<ShippingAddress>(dto);
+            entity.UserId = userId;
+            entity.CreatedAt = DateTime.UtcNow;
+            entity.UpdatedAt = DateTime.UtcNow;
+            entity = await _service.AddAsync(entity);
+            var result = _mapper.Map<ShippingAddressDto>(entity);
+            return CreatedAtAction(nameof(GetById), new { userId, id = result.Id }, result);
+        }
+
+        [HttpGet("{id}")]
+        public async Task<ActionResult<ShippingAddressDto>> GetById(Guid userId, Guid id)
+        {
+            var addresses = await _service.ListByUserAsync(userId);
+            var entity = addresses.FirstOrDefault(a => a.Id == id);
+            if (entity == null) return NotFound();
+            return Ok(_mapper.Map<ShippingAddressDto>(entity));
+        }
+
+        [HttpPut("{id}")]
+        public async Task<IActionResult> Update(Guid userId, Guid id, ShippingAddressCreateUpdateDto dto)
+        {
+            var entity = _mapper.Map<ShippingAddress>(dto);
+            entity.Id = id;
+            entity.UserId = userId;
+            entity.UpdatedAt = DateTime.UtcNow;
+            await _service.UpdateAsync(entity);
+            return NoContent();
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete(Guid userId, Guid id)
+        {
+            await _service.DeleteAsync(id, userId);
+            return NoContent();
+        }
+    }
+}

--- a/src/DBStore.Api/appsettings.json
+++ b/src/DBStore.Api/appsettings.json
@@ -8,5 +8,10 @@
   "ConnectionStrings": {
     "DefaultConnection": "Server=aws-0-sa-east-1.pooler.supabase.com;Port=5432;Database=postgres;User Id=postgres.ffgemqzyzytivikktofs;Password=Chupame1huevo!;SSL Mode=Require;"
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Jwt": {
+    "Key": "ReplaceWithAStrongKey",
+    "Issuer": "DBStoreApi",
+    "Audience": "DBStoreClient"
+  }
 }


### PR DESCRIPTION
## Summary
- implement API controllers for products, carts, favorites, orders, shipping addresses and audit logs
- add JWT configuration placeholder to `appsettings.json`

## Testing
- `dotnet test` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852e14796e48324b2135e6dc4d3cbe1